### PR TITLE
Switch to non-deprecated Action Mailer require

### DIFF
--- a/lib/email_spec.rb
+++ b/lib/email_spec.rb
@@ -1,6 +1,6 @@
 unless defined?(Pony) or defined?(ActionMailer)
   Kernel.warn("Neither Pony nor ActionMailer appear to be loaded so email-spec is requiring ActionMailer.")
-  require 'actionmailer'
+  require 'action_mailer'
 end
 
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__))) unless $LOAD_PATH.include?(File.expand_path(File.dirname(__FILE__)))


### PR DESCRIPTION
Hey Ben,

Just a small change which now uses "action_mailer" rather than "actionmailer" as the require when it can't find Pony or ActionMailer. Cheers.
