### PR TITLE
Allow delivered_to matcher to accept names in the email addresses.

### DIFF
--- a/lib/email_spec/matchers.rb
+++ b/lib/email_spec/matchers.rb
@@ -37,25 +37,25 @@ module EmailSpec
           email_or_object.kind_of?(String) ? email_or_object : email_or_object.email
         end
 
-        @expected_email_addresses = emails.sort
+        @expected_recipients = Mail::ToField.new(emails).addrs.map(&:to_s).sort
       end
 
       def description
-        "be delivered to #{@expected_email_addresses.inspect}"
+        "be delivered to #{@expected_recipients.inspect}"
       end
 
       def matches?(email)
         @email = email
-        @actual_recipients = (Array(email.to) || []).sort
-        @actual_recipients == @expected_email_addresses
+        @actual_recipients = (email.header[:to].addrs || []).map(&:to_s).sort
+        @actual_recipients == @expected_recipients
       end
 
       def failure_message
-        "expected #{@email.inspect} to deliver to #{@expected_email_addresses.inspect}, but it delivered to #{@actual_recipients.inspect}"
+        "expected #{@email.inspect} to deliver to #{@expected_recipients.inspect}, but it delivered to #{@actual_recipients.inspect}"
       end
 
       def negative_failure_message
-        "expected #{@email.inspect} not to deliver to #{@expected_email_addresses.inspect}, but it did"
+        "expected #{@email.inspect} not to deliver to #{@expected_recipients.inspect}, but it did"
       end
     end
 
@@ -80,8 +80,7 @@ module EmailSpec
         @actual_sender = (email.header[:from].addrs || []).first
 
         !@actual_sender.nil? &&
-          @actual_sender.address == @expected_sender.address &&
-          @actual_sender.display_name == @expected_sender.display_name
+          @actual_sender.to_s == @expected_sender.to_s
       end
 
       def failure_message

--- a/spec/email_spec/matchers_spec.rb
+++ b/spec/email_spec/matchers_spec.rb
@@ -54,10 +54,15 @@ describe EmailSpec::Matchers do
   end
 
   describe "#deliver_to" do
-    it "should match when the email is set to deliver to the specidied address" do
+    it "should match when the email is set to deliver to the specified address" do
       email = Mail::Message.new(:to => "jimmy_bean@yahoo.com")
 
       deliver_to("jimmy_bean@yahoo.com").should match(email)
+    end
+
+    it "should match when the email is set to deliver to the specified name and address" do
+      email = Mail::Message.new(:to => "Jimmy Bean <jimmy_bean@yahoo.com>")
+      deliver_to("Jimmy Bean <jimmy_bean@yahoo.com>").should match(email)
     end
 
     it "should match when a list of emails is exact same as all of the email's recipients" do
@@ -72,12 +77,33 @@ describe EmailSpec::Matchers do
       email = Mail::Message.new(:to => addresses)
       deliver_to(addresses).should match(email)
     end
+    
+    it "should match when the names and email addresses match in any order" do
+      addresses = ["James <james@yahoo.com>", "Karen <karen@yahoo.com>"]
+      email = Mail::Message.new(:to => addresses.reverse)
+      deliver_to(addresses).should match(email)
+    end
 
     it "should use the passed in objects :email method if not a string" do
       email = Mail::Message.new(:to => "jimmy_bean@yahoo.com")
       user = mock("user", :email => "jimmy_bean@yahoo.com")
 
       deliver_to(user).should match(email)
+    end
+
+    it "should not match when the email does not have a recipient" do
+      email = Mail::Message.new(:to => nil)
+      deliver_to("jimmy_bean@yahoo.com").should_not match(email)
+    end
+
+    it "should not match when the email addresses match but the names do not" do
+      email = Mail::Message.new(:to => "Jimmy Bean <jimmy_bean@yahoo.com>")
+      deliver_to("Freddy Noe <jimmy_bean@yahoo.com>").should_not match(email)
+    end
+
+    it "should not match when the names match but the email addresses do not" do
+      email = Mail::Message.new(:to => "Jimmy Bean <jimmy_bean@yahoo.com>")
+      deliver_to("Jimmy Bean <freddy_noe@yahoo.com>").should_not match(email)
     end
 
     it "should give correct failure message when the email is not set to deliver to the specified address" do


### PR DESCRIPTION
Basically, this does for the To field what Dan Dofter did for the From field over a year ago (6c50c68a3f1c602e8759294e8364ab13a00545ab). Hope you'll pull it. Let me know if you spot problems or want changes.
