### PR TITLE
Fix for undefined 'current_email_address' bug when working with steak

### DIFF
--- a/lib/email_spec/helpers.rb
+++ b/lib/email_spec/helpers.rb
@@ -148,6 +148,12 @@ module EmailSpec
       AddressConverter.instance.convert(@last_email_address)
     end
 
+    # Overwrite this method to set default email address, for example:
+    # last_email_address || @current_user.email
+    def current_email_address
+      last_email_address
+    end
+
 
     def mailbox_for(address)
       super(convert_address(address)) # super resides in Deliveries


### PR DESCRIPTION
When I tried to use email_spec with steak ( https://github.com/cavalle/steak ), it throwed:
    NameError: undefined local variable or method `current_email_address'

I've made a quick fix for it - i've just added current_email_address method to email_spec helpers.rb with invokation of last_email_address, that way it will either work with steak, and with cucumber (overwriting that method by module EmailHelpers from step definitions generator for cucumber, email_steps.rb). Of course we can also overwrite that method when working with steak too.
