### PR TITLE
Fix for issue #67.

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,8 @@
 == 1.2.x (git)
 
+  === Bugfixes
+  * find_email now allows with_subject and with_text to be either a String or Regexp. Issue #67. (Curtis Miller)
+
 == 1.2 2011-06-16
 
  === New features

--- a/examples/rails3_root/Gemfile.lock
+++ b/examples/rails3_root/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    email_spec (1.1.1)
+    email_spec (1.2.0)
       mail (~> 2.2)
       rspec (~> 2.0)
 

--- a/examples/rails3_root/features/errors.feature
+++ b/examples/rails3_root/features/errors.feature
@@ -14,9 +14,17 @@ Feature: Email-spec errors example
     Then I should receive an email
     When "example@example.com" opens the email with subject "no email"
 
+  Scenario: I fail to open an email with incorrect subject
+    Then I should receive an email
+    When "example@example.com" opens the email with subject /no email/
+
   Scenario: I fail to open an email with incorrect text
     Then I should receive an email
     When "example@example.com" opens the email with text "no email"
+
+  Scenario: I fail to open an email with incorrect text
+    Then I should receive an email
+    When "example@example.com" opens the email with text /no email/
 
   Scenario: I fail to receive an email with the expected link
     Then I should receive an email

--- a/examples/rails3_root/features/example.feature
+++ b/examples/rails3_root/features/example.feature
@@ -14,7 +14,7 @@ Feature: EmailSpec Example -- Prevent Bots from creating accounts
     And I am on the homepage
     And I submit my registration information
 
-  Scenario: First person signup (as myself) with two ways of opening email
+  Scenario: First person signup (as myself) with three ways of opening email
     Then I should receive an email
     And I should have 1 email
 
@@ -30,12 +30,18 @@ Feature: EmailSpec Example -- Prevent Bots from creating accounts
     And I should see "Joe Someone" in the email body
     And I should see "confirm" in the email body
 
+    # Opening email #3
+    When I open the email with subject /Account confirmation/
+    Then I should see "Account confirmation" in the email subject
+    And I should see "Joe Someone" in the email body
+    And I should see "confirm" in the email body
+
     When I follow "Click here to confirm your account!" in the email
     Then I should see "Confirm your new account"
 
     And "foo@bar.com" should have no emails
 
-  Scenario: Third person signup (emails sent to others) with two ways of opening email
+  Scenario: Third person signup (emails sent to others) with three ways of opening email
     Then "foo@bar.com" should have no emails
     And "example@example.com" should receive an email
     And "example@example.com" should have 1 email
@@ -48,6 +54,12 @@ Feature: EmailSpec Example -- Prevent Bots from creating accounts
 
     # Opening email #2
     When "example@example.com" opens the email with subject "Account confirmation"
+    Then they should see "Account confirmation" in the email subject
+    And they should see "Joe Someone" in the email body
+    And they should see "confirm" in the email body
+
+    # Opening email #3
+    When "example@example.com" opens the email with subject /Account confirmation/
     Then they should see "Account confirmation" in the email subject
     And they should see "Joe Someone" in the email body
     And they should see "confirm" in the email body
@@ -67,5 +79,15 @@ Feature: EmailSpec Example -- Prevent Bots from creating accounts
 
     # Opening email #1
     When I open the email
+    Then I should see "This is the HTML part" in the email html part body
+    And I should see "This is the text part" in the email text part body
+
+    # Opening email #2
+    When I open the email with text "This is the HTML part"
+    Then I should see "This is the HTML part" in the email html part body
+    And I should see "This is the text part" in the email text part body
+
+    # Opening email #3
+    When I open the email with text /This is the HTML part/
     Then I should see "This is the HTML part" in the email html part body
     And I should see "This is the text part" in the email text part body

--- a/examples/sinatra_root/features/errors.feature
+++ b/examples/sinatra_root/features/errors.feature
@@ -14,9 +14,17 @@ Feature: Email-spec errors example
     Then I should receive an email
     When "example@example.com" opens the email with subject "no email"
 
+  Scenario: I fail to open an email with incorrect subject
+    Then I should receive an email
+    When "example@example.com" opens the email with subject /no email/
+
   Scenario: I fail to open an email with incorrect text
     Then I should receive an email
     When "example@example.com" opens the email with text "no email"
+
+  Scenario: I fail to open an email with incorrect text
+    Then I should receive an email
+    When "example@example.com" opens the email with text /no email/
 
   Scenario: I fail to receive an email with the expected link
     Then I should receive an email

--- a/examples/sinatra_root/features/example.feature
+++ b/examples/sinatra_root/features/example.feature
@@ -14,7 +14,7 @@ Feature: EmailSpec Example -- Prevent Bots from creating accounts
     And I am on the homepage
     And I submit my registration information
 
-  Scenario: First person signup (as myself) with two ways of opening email
+  Scenario: First person signup (as myself) with three ways of opening email
     Then I should receive an email
     And I should have 1 email
 
@@ -30,12 +30,18 @@ Feature: EmailSpec Example -- Prevent Bots from creating accounts
     And I should see "Joe Someone" in the email body
     And I should see "confirm" in the email body
 
+    # Opening email #3
+    When I open the email with subject /Account confirmation/
+    Then I should see "Account confirmation" in the email subject
+    And I should see "Joe Someone" in the email body
+    And I should see "confirm" in the email body
+
     When I follow "Click here to confirm your account!" in the email
     Then I should see "Confirm your new account"
 
     And "foo@bar.com" should have no emails
 
-  Scenario: Third person signup (emails sent to others) with two ways of opening email
+  Scenario: Third person signup (emails sent to others) with three ways of opening email
     Then "foo@bar.com" should have no emails
     And "example@example.com" should receive an email
     And "example@example.com" should have 1 email
@@ -52,6 +58,12 @@ Feature: EmailSpec Example -- Prevent Bots from creating accounts
     And they should see "Joe Someone" in the email body
     And they should see "confirm" in the email body
 
+    # Opening email #3
+    When "example@example.com" opens the email with subject /Account confirmation/
+    Then they should see "Account confirmation" in the email subject
+    And they should see "Joe Someone" in the email body
+    And they should see "confirm" in the email body
+
     When they follow "Click here to confirm your account!" in the email
     Then they should see "Confirm your new account"
 
@@ -60,3 +72,22 @@ Feature: EmailSpec Example -- Prevent Bots from creating accounts
 
   Scenario: Declarative First Person signup
     Then they should receive an email with a link to a confirmation page
+
+  Scenario: Checking for text in different parts
+    Then I should receive an email
+    And I should have 1 email
+
+    # Opening email #1
+    When I open the email
+    Then I should see "This is the HTML part" in the email html part body
+    And I should see "This is the text part" in the email text part body
+
+    # Opening email #2
+    When I open the email with text "This is the HTML part"
+    Then I should see "This is the HTML part" in the email html part body
+    And I should see "This is the text part" in the email text part body
+
+    # Opening email #3
+    When I open the email with text /This is the HTML part/
+    Then I should see "This is the HTML part" in the email html part body
+    And I should see "This is the text part" in the email text part body

--- a/examples/sinatra_root/lib/example_sinatra_app.rb
+++ b/examples/sinatra_root/lib/example_sinatra_app.rb
@@ -16,15 +16,25 @@ class ExampleSinatraApp < Sinatra::Base
 
   post '/signup' do
     user = params[:user]
-    body = <<-EOHTML
+    body = <<-EOTEXT
+  Hello #{user['name']}!
+
+  Copy and paste this URL into your browser to confirm your account!
+
+  http://www.example.com/confirm
+  This is the text part.
+    EOTEXT
+    html_body = <<-EOHTML
   Hello #{user['name']}!
 
   <a href="http://www.example.com/confirm">Click here to confirm your account!</a>
+  This is the HTML part.
     EOHTML
     Pony.mail(:from => 'admin@example.com',
               :to => user['email'],
               :subject => 'Account confirmation',
-              :body => body
+              :body => body,
+              :html_body => html_body
              )
              'Thanks!  Go check your email!'
   end

--- a/features/rails3_app.feature
+++ b/features/rails3_app.feature
@@ -14,8 +14,8 @@ I want to verify that the example rails 3 app runs all of it's features as expec
     And I run "bundle exec cucumber features -q --no-color" in the rails3 app
     Then I should see the following summary report:
     """
-    13 scenarios (5 failed, 8 passed)
-    110 steps (5 failed, 1 skipped, 104 passed)
+    15 scenarios (7 failed, 8 passed)
+    136 steps (7 failed, 1 skipped, 128 passed)
     """
 
    When I run "rake spec RAILS_ENV=test" in the rails3 app

--- a/features/sinatra_app.feature
+++ b/features/sinatra_app.feature
@@ -9,6 +9,6 @@ I want to verify that the example sinatra app runs all of it's features as expec
     When I run "bundle exec cucumber features -q --no-color" in the sinatra app
     Then I should see the following summary report:
     """
-    9 scenarios (5 failed, 4 passed)
-    75 steps (5 failed, 1 skipped, 69 passed)
+    12 scenarios (7 failed, 5 passed)
+    110 steps (7 failed, 1 skipped, 102 passed)
     """

--- a/lib/email_spec/helpers.rb
+++ b/lib/email_spec/helpers.rb
@@ -54,12 +54,15 @@ module EmailSpec
       email_spec_hash[:read_emails][convert_address(address)] ||= []
     end
 
+    # Should be able to accept String or Regexp options.
     def find_email(address, opts={})
       address = convert_address(address)
       if opts[:with_subject]
-        mailbox_for(address).find { |m| m.subject =~ Regexp.new(Regexp.escape(opts[:with_subject])) }
+        expected_subject = (opts[:with_subject].is_a?(String) ? Regexp.escape(opts[:with_subject]) : opts[:with_subject])
+        mailbox_for(address).find { |m| m.subject =~ Regexp.new(expected_subject) }
       elsif opts[:with_text]
-        mailbox_for(address).find { |m| m.default_part_body =~ Regexp.new(Regexp.escape(opts[:with_text])) }
+        expected_text = (opts[:with_text].is_a?(String) ? Regexp.escape(opts[:with_text]) : opts[:with_text])
+        mailbox_for(address).find { |m| m.default_part_body =~ Regexp.new(expected_text) }
       else
         mailbox_for(address).first
       end

--- a/lib/email_spec/matchers.rb
+++ b/lib/email_spec/matchers.rb
@@ -164,7 +164,7 @@ module EmailSpec
       CcTo.new(expected_email_addresses_or_objects_that_respond_to_email.flatten)
     end
 
-      RSpec::Matchers.define :have_subject do
+    RSpec::Matchers.define :have_subject do
       match do |given|
         given_subject = given.subject
         expected_subject = expected.first
@@ -185,7 +185,7 @@ module EmailSpec
       end
     end
     
-      RSpec::Matchers.define :include_email_with_subject do
+    RSpec::Matchers.define :include_email_with_subject do
       match do |given_emails|
         expected_subject = expected.first
         
@@ -205,7 +205,7 @@ module EmailSpec
       end
     end
 
-      RSpec::Matchers.define :have_body_text do
+    RSpec::Matchers.define :have_body_text do
       match do |given|
         expected_text = expected.first
         
@@ -232,7 +232,7 @@ module EmailSpec
       email_headers.fields.inject({}) { |hash, field| hash[field.field.class::FIELD_NAME] = field.to_s; hash }
     end
 
-      RSpec::Matchers.define :have_header do
+    RSpec::Matchers.define :have_header do
       match do |given|
         given_header = given.header
         expected_name, expected_value = *expected

--- a/lib/generators/email_spec/steps/templates/email_steps.rb
+++ b/lib/generators/email_spec/steps/templates/email_steps.rb
@@ -60,6 +60,10 @@ Then /^(?:I|they|"([^"]*?)") should receive (an|no|\d+) emails? with subject "([
   unread_emails_for(address).select { |m| m.subject =~ Regexp.new(Regexp.escape(subject)) }.size.should == parse_email_count(amount)
 end
 
+Then /^(?:I|they|"([^"]*?)") should receive (an|no|\d+) emails? with subject \/([^"]*?)\/$/ do |address, amount, subject|
+  unread_emails_for(address).select { |m| m.subject =~ Regexp.new(subject) }.size.should == parse_email_count(amount)
+end
+
 Then /^(?:I|they|"([^"]*?)") should receive an email with the following body:$/ do |address, expected_body|
   open_email(address, :with_text => expected_body)
 end
@@ -77,8 +81,16 @@ When /^(?:I|they|"([^"]*?)") opens? the email with subject "([^"]*?)"$/ do |addr
   open_email(address, :with_subject => subject)
 end
 
+When /^(?:I|they|"([^"]*?)") opens? the email with subject \/([^"]*?)\/$/ do |address, subject|
+  open_email(address, :with_subject => Regexp.new(subject))
+end
+
 When /^(?:I|they|"([^"]*?)") opens? the email with text "([^"]*?)"$/ do |address, text|
   open_email(address, :with_text => text)
+end
+
+When /^(?:I|they|"([^"]*?)") opens? the email with text \/([^"]*?)\/$/ do |address, text|
+  open_email(address, :with_text => Regexp.new(text))
 end
 
 #

--- a/spec/email_spec/helpers_spec.rb
+++ b/spec/email_spec/helpers_spec.rb
@@ -144,21 +144,32 @@ describe EmailSpec::Helpers do
         end
 
         it "should open the email with subject" do
-          open_email(@to, :with_subject => @subject).should == @email
+          open_email(@to, :with_subject => @expected).should == @email
         end
       end
 
-      describe 'simple subject' do
+      describe 'simple string subject' do
         before do
-          @subject = 'This is a simple subject'
+          @subject  = 'This is a simple subject'
+          @expected = 'a simple'
         end
 
         it_should_behave_like 'something that opens the email with subject'
       end
 
-      describe 'with regex sensitive characters' do
+      describe 'string with regex sensitive characters' do
         before do
-          @subject = '[app name] Contains regex characters?'
+          @subject  = '[app name] Contains regex characters?'
+          @expected = 'regex characters?'
+        end
+
+        it_should_behave_like 'something that opens the email with subject'
+      end
+
+      describe 'regular expression' do
+        before do
+          @subject = "This is a simple subject"
+          @expected = /a simple/
         end
 
         it_should_behave_like 'something that opens the email with subject'
@@ -178,7 +189,7 @@ describe EmailSpec::Helpers do
         end
       end
 
-      describe 'simple text' do
+      describe 'simple string text' do
         before do
           @body = 'This is an email body that is very simple'
           @text = 'email body'
@@ -187,10 +198,19 @@ describe EmailSpec::Helpers do
         it_should_behave_like 'something that opens the email with text'
       end
 
-      describe 'with regex sensitive characters' do
+      describe 'string with regex sensitive characters' do
         before do
           @body = 'This is an email body. It contains some [regex] characters?'
           @text = '[regex] characters?'
+        end
+
+        it_should_behave_like 'something that opens the email with text'
+      end
+
+      describe 'regular expression' do
+        before do
+          @body = 'This is an email body.'
+          @text = /an\ email/
         end
 
         it_should_behave_like 'something that opens the email with text'


### PR DESCRIPTION
Allow for both String and Regex arguments for the subject and text of find_email. Closes #67.
