### PR TITLE
documentation update for RSpec deprecation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -63,7 +63,7 @@ First you need to require email_spec in your spec_helper.rb:
 You will then need to include EmailSpec::Helpers and EmailSpec::Matchers in your example groups.
 If you want to have access to the helpers and matchers in all of your examples you can do the following in your spec_helper.rb:
 
-  Spec::Runner.configure do |config|
+  RSpec.configure do |config|
     config.include(EmailSpec::Helpers)
     config.include(EmailSpec::Matchers)
   end


### PR DESCRIPTION
Small documentation update for an RSpec deprecation warning

---

DEPRECATION WARNING: you are using deprecated behaviour that will
be removed from a future version of RSpec.

/spec/spec_helper.rb:12
- Spec::Runner.configure is deprecated.
- please use RSpec.configure instead.
