### PR TITLE
Explicitly require mail

### DIFF
--- a/lib/email_spec.rb
+++ b/lib/email_spec.rb
@@ -6,6 +6,7 @@ end
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__))) unless $LOAD_PATH.include?(File.expand_path(File.dirname(__FILE__)))
 
 require 'rspec'
+require 'mail'
 require 'email_spec/background_processes'
 require 'email_spec/deliveries'
 require 'email_spec/address_converter'


### PR DESCRIPTION
Need to require 'mail' because applications that only require 'email_spec' will get a name error when mail_ext.rb is loaded.
