### PR TITLE
Use launchy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,5 @@ gem 'capybara'
 gem 'database_cleaner'
 
 gem "test-unit"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+PATH
+  remote: .
+  specs:
+    email_spec (1.2.1)
+      launchy (~> 2.0)
+      mail (~> 2.2)
+      rspec (~> 2.0)
+
 GEM
   remote: http://gemcutter.org/
   specs:
@@ -28,6 +36,7 @@ GEM
       activemodel (= 3.0.0.rc)
       activesupport (= 3.0.0.rc)
     activesupport (3.0.0.rc)
+    addressable (2.2.6)
     arel (0.4.0)
       activesupport (>= 3.0.0.beta)
     autotest (4.3.2)
@@ -79,6 +88,8 @@ GEM
       rubyforge (>= 2.0.0)
     json (1.4.6)
     json_pure (1.4.6)
+    launchy (2.0.5)
+      addressable (~> 2.2.6)
     mail (2.2.9)
       activesupport (>= 2.3.6)
       i18n (~> 0.4.1)
@@ -156,6 +167,7 @@ DEPENDENCIES
   cucumber-sinatra
   database_cleaner
   delayed_job (>= 2.0.3)
+  email_spec!
   growl-glue
   jeweler
   mail

--- a/email_spec.gemspec
+++ b/email_spec.gemspec
@@ -175,13 +175,16 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<mail>, ["~> 2.2"])
       s.add_runtime_dependency(%q<rspec>, ["~> 2.0"])
+      s.add_runtime_dependency(%q<launchy>, ["~> 2.0"])
     else
       s.add_dependency(%q<mail>, ["~> 2.2"])
       s.add_dependency(%q<rspec>, ["~> 2.0"])
+      s.add_dependency(%q<launchy>, ["~> 2.0"])
     end
   else
     s.add_dependency(%q<mail>, ["~> 2.2"])
     s.add_dependency(%q<rspec>, ["~> 2.0"])
+    s.add_dependency(%q<launchy>, ["~> 2.0"])
   end
 end
 

--- a/examples/rails3_root/Gemfile.lock
+++ b/examples/rails3_root/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ../../
   specs:
-    email_spec (1.2.0)
+    email_spec (1.2.1)
+      launchy (~> 2.0)
       mail (~> 2.2)
       rspec (~> 2.0)
 
@@ -35,6 +36,7 @@ GEM
       activemodel (= 3.0.0.rc)
       activesupport (= 3.0.0.rc)
     activesupport (3.0.0.rc)
+    addressable (2.2.6)
     arel (0.4.0)
       activesupport (>= 3.0.0.beta)
     builder (2.1.2)
@@ -67,6 +69,8 @@ GEM
       trollop (~> 1.16.2)
     i18n (0.4.1)
     json_pure (1.4.3)
+    launchy (2.0.5)
+      addressable (~> 2.2.6)
     mail (2.2.5)
       activesupport (>= 2.3.6)
       mime-types

--- a/lib/email_spec/email_viewer.rb
+++ b/lib/email_spec/email_viewer.rb
@@ -73,11 +73,11 @@ module EmailSpec
 
     # TODO: use the launchy gem for this stuff...
     def self.open_in_text_editor(filename)
-      `open #{filename}`
+      Launchy.open(URI.parse("file://#{File.expand_path(filename)}"), :application => :editor)
     end
 
     def self.open_in_browser(filename)
-      `open #{filename}`
+      Launchy.open(URI.parse("file://#{File.expand_path(filename)}"))
     end
 
     def self.tmp_email_filename(extension = '.txt')


### PR DESCRIPTION
I'm not 100% sure that I did the `:application` option right when invoking launchy (and it might not even need it).

I required v2 because that's where the gem said it would have a stable API. v0.4 may work, too, especially without the `:application` option.
