### PR TITLE
Rails route helper update for readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -113,7 +113,8 @@ Examples for the #signup method in UserMailer:
   describe "Signup Email" do
     include EmailSpec::Helpers
     include EmailSpec::Matchers
-    include ActionController::UrlWriter
+    # include ActionController::UrlWriter - old rails
+    include Rails.application.routes.url_helpers
 
     before(:all) do
       @email = UserMailer.create_signup("jojo@yahoo.com", "Jojo Binks")


### PR DESCRIPTION
In rails 3.1 the url writer has moved, here's an update for the example to get route helpers loaded in the mail spec.
