### PR TITLE
Fix email viewer for complex content types

### DIFF
--- a/lib/email_spec/email_viewer.rb
+++ b/lib/email_spec/email_viewer.rb
@@ -17,7 +17,7 @@ module EmailSpec
 
     def self.save_and_open_all_html_emails
       all_emails.each_with_index do |m, index|
-        if m.multipart? && html_part = m.parts.detect{ |p| p.content_type == 'text/html' }
+        if m.multipart? && html_part = m.parts.detect{ |p| p.content_type.include?('text/html') }
           filename = tmp_email_filename("-#{index}.html")
           File.open(filename, "w") do |f|
             f.write m.parts[1].body
@@ -32,7 +32,7 @@ module EmailSpec
 
       File.open(filename, "w") do |f|
         all_emails.each do |m|
-          if m.multipart? && text_part = m.parts.detect{ |p| p.content_type == 'text/plain' }
+          if m.multipart? && text_part = m.parts.detect{ |p| p.content_type.include?('text/plain') }
             m.ordered_each{|k,v| f.write "#{k}: #{v}\n" }
             f.write text_part.body
           else


### PR DESCRIPTION
In Rails 3.1, and maybe others, it includes the charset in the content
type, ex. "text/html; charset=UTF-8".

Previous to this commit, email-spec was checking via == 'text/html';
this changes it to check if 'text/html' is included in the content type.

Also, If a spec is wanted for this, I'll need to know which version of ruby the project was intended to run against, as I couldn't run rake due to ffi 0.6.3 not compiling on ruby 1.9.3, and removing the Gemfile.lock resulted in a version of cucumber that wasn't compatible with the project. Simplest solution would be to switch to the same ruby you use.
