### PR TITLE
If a helper is passed an object that responds to email, call that method on the object.

### DIFF
--- a/lib/email_spec/helpers.rb
+++ b/lib/email_spec/helpers.rb
@@ -88,7 +88,7 @@ module EmailSpec
     def find_email!(address, opts={})
       email = find_email(address, opts)
       if current_email_address.nil?
-        raise EmailSpec::NoEmailAddressProvided, "No email address has been provided. Make sure current_email_address is returning something."  
+        raise EmailSpec::NoEmailAddressProvided, "No email address has been provided. Make sure current_email_address is returning something."
       elsif email.nil?
         error = "#{opts.keys.first.to_s.humanize.downcase unless opts.empty?} #{('"' + opts.values.first.to_s + '"') unless opts.empty?}"
         raise EmailSpec::CouldNotFindEmailError, "Could not find email #{error} in the mailbox for #{current_email_address}. \n Found the following emails:\n\n #{all_emails.to_s}"
@@ -168,6 +168,7 @@ module EmailSpec
 
 
     def mailbox_for(address)
+      address = address.email if address.respond_to?(:email)
       super(convert_address(address)) # super resides in Deliveries
     end
 


### PR DESCRIPTION
In many places, my rspec request tests are calling something like:

```
unread_emails_for(user.email)
```

Seems to me it would be nice if the email-spec helpers recognized an object responds to `email`, and in that case called that method internally.  It would be nice to write all my specs as:

```
unread_emails_for(user)
```

Code attached for making this work in all email helpers. I'm interested to know what others think about this. Any feedback welcome.
