### PR TITLE
Visiting a link within an email when no email is found

### DIFF
--- a/lib/email_spec/helpers.rb
+++ b/lib/email_spec/helpers.rb
@@ -10,7 +10,7 @@ module EmailSpec
       if address.nil? || address.empty?
         email = current_email
       else
-        email = find_email(address)
+        email = find_email!(address)
       end
       visit(parse_email_for_link(email, link_text))
     end
@@ -88,7 +88,7 @@ module EmailSpec
     def find_email!(address, opts={})
       email = find_email(address, opts)
       if current_email_address.nil?
-        raise EmailSpec::NoEmailAddressProvided, "No email address has been provided. Make sure current_email_address is returning something."  
+        raise EmailSpec::NoEmailAddressProvided, "No email address has been provided. Make sure current_email_address is returning something."
       elsif email.nil?
         error = "#{opts.keys.first.to_s.humanize.downcase unless opts.empty?} #{('"' + opts.values.first.to_s + '"') unless opts.empty?}"
         raise EmailSpec::CouldNotFindEmailError, "Could not find email #{error} in the mailbox for #{current_email_address}. \n Found the following emails:\n\n #{all_emails.to_s}"

--- a/spec/email_spec/helpers_spec.rb
+++ b/spec/email_spec/helpers_spec.rb
@@ -2,6 +2,13 @@ require File.dirname(__FILE__) + '/../spec_helper'
 
 describe EmailSpec::Helpers do
   include EmailSpec::Helpers
+
+  describe "#visit_in_email" do
+    it "raises an exception when an email is not found" do
+      expect { visit_in_email("Some link", "foo@bar.com") }.to raise_error(EmailSpec::CouldNotFindEmailError)
+    end
+  end
+
   describe "#parse_email_for_link" do
     it "properly finds links with text" do
       email = Mail.new(:body =>  %(<a href="/path/to/page">Click Here</a>))


### PR DESCRIPTION
We modified visit_in_email to use find_email! instead of find_email in order to notify the consumer of visit_in_email that an email is not found.
