### PR TITLE
include Capybara::DSL rather than Capybara

### DIFF
--- a/examples/sinatra_root/features/support/env.rb
+++ b/examples/sinatra_root/features/support/env.rb
@@ -13,7 +13,7 @@ ExampleSinatraApp.set(:environment, :test)
 Capybara.app = ExampleSinatraApp
 
 class ExampleSinatraAppWorld
-  include Capybara
+  include Capybara::DSL
 end
 
 World do


### PR DESCRIPTION
So today, we noticed that your gem was throwing a deprecation warning for including Capybara, rather than Capybara::DSL. So we fixed it. :banana: 

Thanks for making a cool thing :] 

-Neil
