### PR TITLE
Force new version of rspec-rails to so that new stubs work correctly.

### DIFF
--- a/email_spec.gemspec
+++ b/email_spec.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "cucumber"
   s.add_development_dependency "cucumber-rails"
   s.add_development_dependency "cucumber-sinatra"
-  s.add_development_dependency "rspec-rails", [">= 2.0.1"]
+  s.add_development_dependency "rspec-rails", [">= 2.14.0"]
   s.add_development_dependency 'delayed_job', ['~> 2.0']
   s.add_development_dependency "pony"
   s.add_development_dependency "sinatra"


### PR DESCRIPTION
Force an update to `rspec-rails` after updating `stub` to `allow` in `helper_spec.rb`. Needed after #135.
