### PR TITLE
Look for bcc if no to specified in matcher

### DIFF
--- a/lib/email_spec/matchers.rb
+++ b/lib/email_spec/matchers.rb
@@ -46,7 +46,11 @@ module EmailSpec
 
       def matches?(email)
         @email = email
-        @actual_recipients = (email.header[:to].addrs || []).map(&:to_s).sort
+        if email.header[:to].nil?
+          @actual_recipients = (email.header[:bcc].addrs || []).map(&:to_s).sort
+        else
+          @actual_recipients = (email.header[:to].addrs || []).map(&:to_s).sort
+        end 
         @actual_recipients == @expected_recipients
       end
 


### PR DESCRIPTION
When sending out an email with only bcc specified, the matcher will fail even if the list is correct. Added a simple fix to look for bcc if to is nil
