### PR TITLE
Add support for the latest RSpec matcher protocol

### DIFF
--- a/examples/rails3_root/Gemfile.lock
+++ b/examples/rails3_root/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    email_spec (1.4.0)
+    email_spec (1.5.0)
       launchy (~> 2.1)
       mail (~> 2.2)
 
@@ -69,7 +69,7 @@ GEM
       json (>= 1.4.6)
     i18n (0.5.0)
     json (1.7.5)
-    launchy (2.1.2)
+    launchy (2.4.2)
       addressable (~> 2.3)
     libwebsocket (0.1.5)
       addressable

--- a/lib/email_spec/matchers.rb
+++ b/lib/email_spec/matchers.rb
@@ -30,9 +30,10 @@ module EmailSpec
         "expected #{@email.inspect} to reply to #{@expected_reply_to.address.inspect}, but it replied to #{@actual_reply_to.inspect}"
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         "expected #{@email.inspect} not to deliver to #{@expected_reply_to.address.inspect}, but it did"
       end
+      alias negative_failure_message failure_message_when_negated
     end
 
     def reply_to(email)
@@ -64,9 +65,10 @@ module EmailSpec
         "expected #{@email.inspect} to deliver to #{@expected_recipients.inspect}, but it delivered to #{@actual_recipients.inspect}"
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         "expected #{@email.inspect} not to deliver to #{@expected_recipients.inspect}, but it did"
       end
+      alias negative_failure_message failure_message_when_negated
     end
 
     def deliver_to(*expected_email_addresses_or_objects_that_respond_to_email)
@@ -97,9 +99,10 @@ module EmailSpec
         %(expected #{@email.inspect} to deliver from "#{@expected_sender.to_s}", but it delivered from "#{@actual_sender.to_s}")
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         %(expected #{@email.inspect} not to deliver from "#{@expected_sender.to_s}", but it did)
       end
+      alias negative_failure_message failure_message_when_negated
     end
 
     def deliver_from(email)
@@ -132,9 +135,10 @@ module EmailSpec
         "expected #{@email.inspect} to bcc to #{@expected_email_addresses.inspect}, but it was bcc'd to #{@actual_recipients.inspect}"
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         "expected #{@email.inspect} not to bcc to #{@expected_email_addresses.inspect}, but it did"
       end
+      alias negative_failure_message failure_message_when_negated
     end
 
     def bcc_to(*expected_email_addresses_or_objects_that_respond_to_email)
@@ -165,9 +169,10 @@ module EmailSpec
         "expected #{@email.inspect} to cc to #{@expected_email_addresses.inspect}, but it was cc'd to #{@actual_recipients.inspect}"
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         "expected #{@email.inspect} not to cc to #{@expected_email_addresses.inspect}, but it did"
       end
+      alias negative_failure_message failure_message_when_negated
     end
 
     def cc_to(*expected_email_addresses_or_objects_that_respond_to_email)
@@ -205,13 +210,14 @@ module EmailSpec
         end
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         if @expected_subject.is_a?(String)
           "expected the subject not to be #{@expected_subject.inspect} but was"
         else
           "expected the subject not to match #{@expected_subject.inspect} but #{@given_subject.inspect} does match it."
         end
       end
+      alias negative_failure_message failure_message_when_negated
     end
 
     def have_subject(subject)
@@ -249,13 +255,14 @@ module EmailSpec
         end
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         if @expected_subject.is_a?(String)
           "expected no email with the subject #{@expected_subject.inspect} but found at least one. Subjects were #{@given_emails.map(&:subject).inspect}"
         else
           "expected no email to have a subject matching #{@expected_subject.inspect} but found at least one. Subjects were #{@given_emails.map(&:subject).inspect}"
         end
       end
+      alias negative_failure_message failure_message_when_negated
     end
 
     def include_email_with_subject(*emails)
@@ -295,13 +302,14 @@ module EmailSpec
         end
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         if @expected_text.is_a?(String)
           "expected the body not to contain #{@expected_text.inspect} but was #{@given_text.inspect}"
         else
           "expected the body not to match #{@expected_text.inspect} but #{@given_text.inspect} does match it."
         end
       end
+      alias negative_failure_message failure_message_when_negated
     end
 
     def have_body_text(text)
@@ -339,13 +347,14 @@ module EmailSpec
         end
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         if @expected_value.is_a?(String)
           "expected the headers not to include '#{@expected_name}: #{@expected_value}' but they were #{mail_headers_hash(@given_header).inspect}"
         else
           "expected the headers not to include '#{@expected_name}' with a value matching #{@expected_value.inspect} but they were #{mail_headers_hash(@given_header).inspect}"
         end
       end
+      alias negative_failure_message failure_message_when_negated
 
       def mail_headers_hash(email_headers)
         email_headers.fields.inject({}) { |hash, field| hash[field.field.class::FIELD_NAME] = field.to_s; hash }

--- a/spec/email_spec/matchers_spec.rb
+++ b/spec/email_spec/matchers_spec.rb
@@ -21,9 +21,10 @@ describe EmailSpec::Matchers do
       "expected #{@matcher.inspect} to match when provided #{@object_to_test_match.inspect}, but it did not"
     end
 
-    def negative_failure_message
+    def failure_message_when_negated
       "expected #{@matcher.inspect} not to match when provided #{@object_to_test_match.inspect}, but it did"
     end
+    alias negative_failure_message failure_message_when_negated
   end
 
   def match(object_to_test_match)
@@ -268,7 +269,7 @@ describe EmailSpec::Matchers do
         matcher = have_subject(/b/)
         matcher.matches?(Mail::Message.new(:subject => "bar"))
 
-        matcher_negative_failure_message(matcher).should == 'expected the subject not to match /b/ but "bar" does match it.'
+        matcher_failure_message_when_negated(matcher).should == 'expected the subject not to match /b/ but "bar" does match it.'
       end
     end
 
@@ -298,18 +299,18 @@ describe EmailSpec::Matchers do
         matcher = have_subject("bar")
         matcher.matches?(Mail::Message.new(:subject => "bar"))
 
-        matcher_negative_failure_message(matcher).should == 'expected the subject not to be "bar" but was'
+        matcher_failure_message_when_negated(matcher).should == 'expected the subject not to be "bar" but was'
       end
     end
   end
 
   describe "#include_email_with_subject" do
-    
+
     describe "when regexps are used" do
-      
+
       it "should match when any email's subject matches passed in regexp" do
         emails = [Mail::Message.new(:subject => "foobar"), Mail::Message.new(:subject => "bazqux")]
-        
+
         include_email_with_subject(/foo/).should match(emails)
         include_email_with_subject(/quux/).should_not match(emails)
       end
@@ -317,52 +318,52 @@ describe EmailSpec::Matchers do
       it "should have a helpful description" do
         matcher = include_email_with_subject(/foo/)
         matcher.matches?([])
-        
+
         matcher.description.should == 'include email with subject matching /foo/'
       end
 
       it "should offer helpful failing messages" do
         matcher = include_email_with_subject(/foo/)
         matcher.matches?([Mail::Message.new(:subject => "bar")])
-        
+
         matcher_failure_message(matcher).should == 'expected at least one email to have a subject matching /foo/, but none did. Subjects were ["bar"]'
       end
 
       it "should offer helpful negative failing messages" do
         matcher = include_email_with_subject(/foo/)
         matcher.matches?([Mail::Message.new(:subject => "foo")])
-        
-        matcher_negative_failure_message(matcher).should == 'expected no email to have a subject matching /foo/ but found at least one. Subjects were ["foo"]'
+
+        matcher_failure_message_when_negated(matcher).should == 'expected no email to have a subject matching /foo/ but found at least one. Subjects were ["foo"]'
       end
     end
-    
+
     describe "when strings are used" do
       it "should match when any email's subject equals passed in subject exactly" do
         emails = [Mail::Message.new(:subject => "foobar"), Mail::Message.new(:subject => "bazqux")]
-        
+
         include_email_with_subject("foobar").should match(emails)
         include_email_with_subject("foo").should_not match(emails)
       end
-      
+
       it "should have a helpful description" do
         matcher = include_email_with_subject("foo")
         matcher.matches?([])
-        
+
         matcher.description.should == 'include email with subject of "foo"'
       end
-      
+
       it "should offer helpful failing messages" do
         matcher = include_email_with_subject("foo")
         matcher.matches?([Mail::Message.new(:subject => "bar")])
-        
+
         matcher_failure_message(matcher).should == 'expected at least one email to have the subject "foo" but none did. Subjects were ["bar"]'
       end
-      
+
       it "should offer helpful negative failing messages" do
         matcher = include_email_with_subject("foo")
         matcher.matches?([Mail::Message.new(:subject => "foo")])
-        
-        matcher_negative_failure_message(matcher).should == 'expected no email with the subject "foo" but found at least one. Subjects were ["foo"]'
+
+        matcher_failure_message_when_negated(matcher).should == 'expected no email with the subject "foo" but found at least one. Subjects were ["foo"]'
       end
     end
   end
@@ -379,14 +380,14 @@ describe EmailSpec::Matchers do
       it "should have a helpful description" do
         matcher = have_body_text(/qux/)
         matcher.matches?(Mail::Message.new(:body => 'foo bar baz'))
-        
+
         matcher.description.should == 'have body matching /qux/'
       end
 
       it "should offer helpful failing messages" do
         matcher = have_body_text(/qux/)
         matcher.matches?(Mail::Message.new(:body => 'foo bar baz'))
-        
+
         matcher_failure_message(matcher).should == 'expected the body to match /qux/, but did not.  Actual body was: "foo bar baz"'
       end
 
@@ -394,37 +395,37 @@ describe EmailSpec::Matchers do
         matcher = have_body_text(/bar/)
         matcher.matches?(Mail::Message.new(:body => 'foo bar baz'))
 
-        matcher_negative_failure_message(matcher).should == 'expected the body not to match /bar/ but "foo bar baz" does match it.'
+        matcher_failure_message_when_negated(matcher).should == 'expected the body not to match /bar/ but "foo bar baz" does match it.'
       end
     end
-    
+
     describe "when strings are used" do
       it "should match when the body includes the text" do
         email = Mail::Message.new(:body => 'foo bar baz')
-        
+
         have_body_text('bar').should match(email)
         have_body_text('qux').should_not match(email)
       end
-      
+
       it "should have a helpful description" do
         matcher = have_body_text('qux')
         matcher.matches?(Mail::Message.new(:body => 'foo bar baz'))
-        
+
         matcher.description.should == 'have body including "qux"'
       end
-      
+
       it "should offer helpful failing messages" do
         matcher = have_body_text('qux')
         matcher.matches?(Mail::Message.new(:body => 'foo bar baz'))
-        
+
         matcher_failure_message(matcher).should == 'expected the body to contain "qux" but was "foo bar baz"'
       end
-      
+
       it "should offer helpful negative failing messages" do
         matcher = have_body_text('bar')
         matcher.matches?(Mail::Message.new(:body => 'foo bar baz'))
-        
-        matcher_negative_failure_message(matcher).should == 'expected the body not to contain "bar" but was "foo bar baz"'
+
+        matcher_failure_message_when_negated(matcher).should == 'expected the body not to contain "bar" but was "foo bar baz"'
       end
     end
 
@@ -448,7 +449,7 @@ describe EmailSpec::Matchers do
     describe "when regexps are used" do
       it "should match when header matches passed in regexp" do
         email = Mail::Message.new(:content_type => "text/html")
-        
+
         have_header(:content_type, /text/).should match(email)
         have_header(:foo, /text/).should_not match(email)
         have_header(:content_type, /bar/).should_not match(email)
@@ -457,53 +458,53 @@ describe EmailSpec::Matchers do
       it "should have a helpful description" do
         matcher = have_header(:content_type, /bar/)
         matcher.matches?(Mail::Message.new(:content_type => "text/html"))
-        
+
         matcher.description.should == 'have header content_type with value matching /bar/'
       end
 
       it "should offer helpful failing messages" do
         matcher = have_header(:content_type, /bar/)
         matcher.matches?(Mail::Message.new(:content_type => "text/html"))
-        
+
         matcher_failure_message(matcher).should == 'expected the headers to include \'content_type\' with a value matching /bar/ but they were {"content-type"=>"text/html"}'
       end
 
       it "should offer helpful negative failing messages" do
         matcher = have_header(:content_type, /text/)
         matcher.matches?(Mail::Message.new(:content_type => "text/html"))
-        
-        matcher_negative_failure_message(matcher).should == 'expected the headers not to include \'content_type\' with a value matching /text/ but they were {"content-type"=>"text/html"}'
+
+        matcher_failure_message_when_negated(matcher).should == 'expected the headers not to include \'content_type\' with a value matching /text/ but they were {"content-type"=>"text/html"}'
       end
     end
-    
+
     describe "when strings are used" do
       it "should match when header equals passed in value exactly" do
         email = Mail::Message.new(:content_type => "text/html")
-        
+
         have_header(:content_type, 'text/html').should match(email)
         have_header(:foo, 'text/html').should_not match(email)
         have_header(:content_type, 'text').should_not match(email)
       end
-      
+
       it "should have a helpful description" do
         matcher = have_header(:content_type, 'text')
         matcher.matches?(Mail::Message.new(:content_type => "text/html"))
-        
+
         matcher.description.should == 'have header content_type: text'
       end
-      
+
       it "should offer helpful failing messages" do
         matcher = have_header(:content_type, 'text')
         matcher.matches?(Mail::Message.new(:content_type => "text/html"))
-        
+
         matcher_failure_message(matcher).should == 'expected the headers to include \'content_type: text\' but they were {"content-type"=>"text/html"}'
       end
-      
+
       it "should offer helpful negative failing messages" do
         matcher = have_header(:content_type, 'text/html')
         matcher.matches?(Mail::Message.new(:content_type => "text/html"))
-        
-        matcher_negative_failure_message(matcher) == 'expected the headers not to include \'content_type: text/html\' but they were {:content_type=>"text/html"}'
+
+        matcher_failure_message_when_negated(matcher) == 'expected the headers not to include \'content_type: text/html\' but they were {:content_type=>"text/html"}'
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ RSpec.configure do |config|
         matcher.failure_message
   end
 
-  def matcher_negative_failure_message(matcher)
+  def matcher_failure_message_when_negated(matcher)
     matcher.respond_to?(:failure_message_for_should_not) ?
         matcher.failure_message_for_should_not :
         matcher.negative_failure_message


### PR DESCRIPTION
This patch fixes the deprecation warnings given when using
email-spec with RSpec 3.0.0.beta2. The negative_failure_message
method has been renamed to failure_message_when_negated and
an alias for negative_failure_message has been added to support
older RSpec releases.
