### PR TITLE
Fix unread emails helper for cached deliveries

### DIFF
--- a/lib/email_spec/helpers.rb
+++ b/lib/email_spec/helpers.rb
@@ -52,7 +52,8 @@ module EmailSpec
     end
 
     def unread_emails_for(address)
-      mailbox_for(address) - read_emails_for(address)
+      read_message_ids = read_emails_for(address).map(&:message_id)
+      mailbox_for(address).reject { |m| read_message_ids.include?(m.message_id) }
     end
 
     def read_emails_for(address)


### PR DESCRIPTION
When delivery method is set to cache, the helper method to find unread
messages in a mailbox can fail to correctly identify the read messages,
because it expects the same ruby objects in the cached deliveries array
and the read messages collection, but this is not reliable because
serializing and de-serializing messages will create new ruby objects.

This commit updates the code to use message ids when subtracting the
collection of read messages from the mailbox to find unread messages.
