### PR TITLE
Travis bundler update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.0.0
   - 2.1.0
 before_install:
-  - gem install bundler -v 1.11.2
+  - gem update bundler
 before_script:
 - bundle install --gemfile=examples/rails4_root/Gemfile
 - bundle install --gemfile=examples/sinatra_root/Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ rvm:
 before_install:
   - gem update bundler
 before_script:
-- bundle install --gemfile=examples/rails4_root/Gemfile
-- bundle install --gemfile=examples/sinatra_root/Gemfile
+  - bundle install --gemfile=examples/rails4_root/Gemfile
+  - bundle install --gemfile=examples/sinatra_root/Gemfile
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+before_install:
+  - gem install bundler -v 1.11.2
 before_script:
 - bundle install --gemfile=examples/rails4_root/Gemfile
 - bundle install --gemfile=examples/sinatra_root/Gemfile


### PR DESCRIPTION
As advised in travis-ci/travis-ci#3531, it seems to be necessary to install a newer bundler version before running `bundle install`.