### PR TITLE
Adds coverage for links surrounded by tags.

### DIFF
--- a/spec/email_spec/helpers_spec.rb
+++ b/spec/email_spec/helpers_spec.rb
@@ -30,6 +30,11 @@ describe EmailSpec::Helpers do
       expect(parse_email_for_link(email, "Click Here")).to eq("/path/to/page")
     end
 
+    it "properly finds links with text surrounded by tags" do
+      email = Mail.new(:body =>  %(<a href="/path/to/page"><strong>Click Here</strong></a>))
+      expect(parse_email_for_link(email, "Click Here")).to eq("/path/to/page")
+    end
+
     it "recognizes img alt properties as text" do
       email = Mail.new(:body => %(<a href="/path/to/page"><img src="http://host.com/images/image.gif" alt="an image" /></a>))
       expect(parse_email_for_link(email, "an image")).to eq("/path/to/page")


### PR DESCRIPTION
This PR adds some missing coverage, and fixes https://github.com/email-spec/email-spec/issues/151, which was already fixed in a previous PR. 