### PR TITLE
Added actionmailer to root gemspec, dropped cucumber-rails and -sinatra.

### DIFF
--- a/email_spec.gemspec
+++ b/email_spec.gemspec
@@ -34,8 +34,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake", ">= 0.8.7"
   s.add_development_dependency "cucumber", '~> 1.3.17'
-  s.add_development_dependency "cucumber-rails", '~> 1.4.2'
-  s.add_development_dependency "cucumber-sinatra", '~> 0.5.0'
+  s.add_development_dependency "actionmailer", "~> 4.2"
   s.add_development_dependency "rack-test"
   s.add_development_dependency "rspec", '~> 3.1'
 


### PR DESCRIPTION
This PR attempts to fix the broken build for `master`. Due to a recently released version of `cucumber-rails`, which drops `rails` from its `gemspec` (see: https://github.com/cucumber/cucumber-rails/pull/294), we stopped having the previously implicit `actionmailer` dependency which was provided via the Rails gem installed by `cucumber-rails`. 

Also, since these two Cucumber gems are in each of the example project's `Gemfile`'s, we no longer need to have them in the root `gemspec`.

Please check it out, thanks! 