### PR TITLE
Add #html method to Mail::Ext (closes #173)

### DIFF
--- a/lib/email_spec/mail_ext.rb
+++ b/lib/email_spec/mail_ext.rb
@@ -6,6 +6,10 @@ module EmailSpec::MailExt
   def default_part_body
     default_part.body
   end
+
+  def html
+    html_part ? html_part.body.raw_source : nil
+  end
 end
 
 Mail::Message.send(:include, EmailSpec::MailExt)

--- a/spec/email_spec/mail_ext_spec.rb
+++ b/spec/email_spec/mail_ext_spec.rb
@@ -31,4 +31,27 @@ describe EmailSpec::MailExt do
       expect(email.default_part.body).to eq(email.default_part_body)
     end
   end
+
+  describe "#html" do
+    it "returns the html part body" do
+      email = Mail.new do
+        html_part { body "This is html" }
+      end
+
+      expect(email.html).to eq("This is html")
+    end
+
+    it "returns a String" do
+      email = Mail.new do
+        html_part { body "This is html" }
+      end
+
+      expect(email.html).to be_a(String)
+    end
+
+    it "returns nil for mail with no html part" do
+      email = Mail.new
+      expect(email.html).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Allows for clearer tests with Capybara matchers. E.g. in mailer specs:

expect(mail.html).to have_css 'p', 'Thank you for joining!'