### PR TITLE
Add info about RSpec 3.1+ and Rails 5 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Scenario: A new person signs up
 
 ### RSpec (3.1+)
 
-First you need to require email_spec in your spec_helper.rb:
+First you need to require `email_spec` in your `spec_helper.rb`:
 
 ```ruby
 require "email_spec"
@@ -62,6 +62,12 @@ require "email_spec/rspec"
 ```
 
 This will load all the helpers that the scenarios can count on. It will also add a `before(:each)` hook so that emails are cleared at the start of each scenario.
+
+If you are upgrading to Rails 5, make sure your `rails_helper.rb` requires `spec_helper` **after** loading the environment. For example:
+```ruby
+require File.expand_path('../../config/environment', __FILE__)
+require 'spec_helper'
+```
 
 ### MiniTest
 


### PR DESCRIPTION
For issue #187 

Anyone that had RSpec installed on Rails 4 prior to May, 2015 will have email-spec fail on them unless they update their `rails_helper.rb` file.

Feel free to change the wording as needed. Thanks!