### PR TITLE
Add Spinach support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ Scenario: A new person signs up
     And "quentin@example.com" should receive an email   # Specify who should receive the email
 ```
 
+### Spinach
+
+To use the helpers and matchers in your Spinach steps, add this to your env.rb:
+
+```ruby
+require 'email_spec/spinach'
+```
+
+Creating shared steps (as for Cucumber above) doesn't fit so well with the Spinach ethos of very compartmentalized steps, so there is no generator for Spinach. It's easy to use the helpers/matchers in your steps. For example:
+
+```ruby
+step 'the last email sent should welcome the user' do
+  expect(last_email_sent).to have_subject('Welcome')
+end
+```
+
 ### RSpec (3.1+)
 
 First you need to require email_spec in your spec_helper.rb:

--- a/lib/email_spec/spinach.rb
+++ b/lib/email_spec/spinach.rb
@@ -1,0 +1,28 @@
+# Require this in your spinach features/support/env.rb file to get access
+# to the helpers and matchers in your steps.
+
+if defined?(ActionMailer)
+  unless [:test, :activerecord, :cache, :file].include?(ActionMailer::Base.delivery_method)
+    ActionMailer::Base.register_observer(EmailSpec::TestObserver)
+  end
+  ActionMailer::Base.perform_deliveries = true
+
+  Spinach.hooks.before_scenario do
+    # Scenario setup
+    case ActionMailer::Base.delivery_method
+      when :test then ActionMailer::Base.deliveries.clear
+      when :cache then ActionMailer::Base.clear_cache
+    end
+  end
+end
+
+Spinach.hooks.after_scenario do
+  EmailSpec::EmailViewer.save_and_open_all_raw_emails if ENV['SHOW_EMAILS']
+  EmailSpec::EmailViewer.save_and_open_all_html_emails if ENV['SHOW_HTML_EMAILS']
+  EmailSpec::EmailViewer.save_and_open_all_text_emails if ENV['SHOW_TEXT_EMAILS']
+end
+
+class Spinach::FeatureSteps
+  include EmailSpec::Helpers
+  include EmailSpec::Matchers
+end


### PR DESCRIPTION
This PR adds support for [Spinach](http://codegram.github.io/spinach/), a popular Cucumber replacement.

It only adds a support file `email_spec/spinach` which is a copy of the `email_spec/cucumber` file but does not provide a generator for steps, as this goes against Spinach's philosophy of trying to keep steps very specific to the feature in question. The matchers and helpers are all Spinach users need here!