### PR TITLE
Improve Regex to allow space between tags and text

### DIFF
--- a/lib/email_spec/helpers.rb
+++ b/lib/email_spec/helpers.rb
@@ -6,8 +6,8 @@ module EmailSpec
   module Helpers
     include Deliveries
 
-    A_TAG_BEGIN_REGEX = %r{<a[^>]*href=['"]?([^'"]*)['"]?[^>]*>(?:(?!</a>).)*?}
-    A_TAG_END_REGEX = %r{(?:(?!</a>).)*?</a>}
+    A_TAG_BEGIN_REGEX = %r{<a[^>]*href=['"]?([^'"]*)['"]?[^>]*>\s*(?:(?!</a>).)*?\s*}
+    A_TAG_END_REGEX = %r{\s*(?:(?!</a>).)*?\s*</a>}
 
     def visit_in_email(link_text, address = '')
       if address.nil? || address.empty?

--- a/spec/email_spec/helpers_spec.rb
+++ b/spec/email_spec/helpers_spec.rb
@@ -37,6 +37,20 @@ describe EmailSpec::Helpers do
       expect(parse_email_for_link(email, "Click Here")).to eq("/path/to/page")
     end
 
+    it "properly finds links with tags and text in new lines" do
+      email = Mail.new(:body =>  <<-HTML
+        <a href="/path/to/app">Welcome</a>
+        <a href="/path/to/page">
+          <strong>
+            Click Here
+          </strong>
+        </a>
+        HTML
+      )
+
+      expect(parse_email_for_link(email, "Click Here")).to eq("/path/to/page")
+    end
+
     it "recognizes img alt properties as text" do
       email = Mail.new(:body => %(<a href="/path/to/page"><img src="http://host.com/images/image.gif" alt="an image" /></a>))
       expect(parse_email_for_link(email, "an image")).to eq("/path/to/page")


### PR DESCRIPTION
When updating from `1.6.0` to `2.1.0` our tests started breaking. The regex was changed to allow other tags inside the link but it broke support for finding links when the `link_text` is in a new line.

I changed the regex to allow any whitespace character between tags and/or text.

Let me know if I need to change something. Thanks for the great gem!