### PR TITLE
Suppress warnings for URI.extract and 2 things

### DIFF
--- a/lib/email_spec/email_viewer.rb
+++ b/lib/email_spec/email_viewer.rb
@@ -17,7 +17,7 @@ module EmailSpec
 
     def self.save_and_open_all_html_emails
       all_emails.each_with_index do |m, index|
-        if m.multipart? && html_part = m.parts.detect{ |p| p.content_type.include?('text/html') }
+        if m.multipart? && m.parts.detect{ |p| p.content_type.include?('text/html') }
           filename = tmp_email_filename("-#{index}.html")
           File.open(filename, "w") do |f|
             f.write m.parts[1].body

--- a/lib/email_spec/helpers.rb
+++ b/lib/email_spec/helpers.rb
@@ -102,7 +102,7 @@ module EmailSpec
       elsif email.nil?
         error = "#{opts.keys.first.to_s.gsub("_", " ").downcase unless opts.empty?} #{('"' + opts.values.first.to_s + '"') unless opts.empty?}"
         raise EmailSpec::CouldNotFindEmailError, "Could not find email #{error} in the mailbox for #{current_email_address}. \n Found the following emails:\n\n #{all_emails.to_s}"
-       end
+      end
       email
     end
 

--- a/lib/email_spec/helpers.rb
+++ b/lib/email_spec/helpers.rb
@@ -85,7 +85,7 @@ module EmailSpec
     end
 
     def links_in_email(email)
-      links = URI.extract(email.default_part_body.to_s, ['http', 'https'])
+      links = URI::Parser.new.extract(email.default_part_body.to_s, ['http', 'https'])
       links.map{|url| HTMLEntities.new.decode(url) }.uniq
     end
 


### PR DESCRIPTION
This PR will suppresses the following warnings:

- lib/email_spec/helpers.rb:88:in `links_in_email': warning: URI.extract is obsolete
- lib/email_spec/helpers.rb:105: warning: mismatched indentations at 'end' with 'if' at 100
- lib/email_spec/email_viewer.rb:20: warning: assigned but unused variable - html_part

Thanks.