### PR TITLE
Extend have_body_text matcher to be able to specify which part in multipart to check

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,15 @@ expect(email).to have_body_text(/Hi Jojo Binks,/)
 ```
 
 
+You can specify which part in multipart to check with `in_html_part` or
+`in_text_part`.
+
+```ruby
+email = UserMailer.("jojo@yahoo.com", "Jojo Binks")
+expect(email).to have_body_text(/This is html/).in_html_part
+expect(email).to have_body_text(/This is text/).in_text_part
+```
+
 ##### have_header(key, value)
 
 This checks that the expected key/value pair is in the headers of the email.

--- a/lib/email_spec/extractors.rb
+++ b/lib/email_spec/extractors.rb
@@ -1,0 +1,45 @@
+module EmailSpec
+  module Extractors
+    class Base
+      attr_accessor :mail
+
+      def initialize(mail)
+        @mail = mail
+      end
+
+      def call
+        part_body ? HTMLEntities.new.decode(part_body) : ''
+      end
+
+      private
+
+      def part_body
+        raise NotImplementedError
+      end
+    end
+
+    class DefaultPartBody < Base
+      private
+
+      def part_body
+        (mail.html_part || mail.text_part || mail).body
+      end
+    end
+
+    class HtmlPartBody < Base
+      private
+
+      def part_body
+        mail.html_part ? mail.html_part.body : nil
+      end
+    end
+
+    class TextPartBody < Base
+      private
+
+      def part_body
+        mail.text_part ? mail.text_part.body : nil
+      end
+    end
+  end
+end

--- a/lib/email_spec/matchers.rb
+++ b/lib/email_spec/matchers.rb
@@ -1,3 +1,5 @@
+require_relative 'extractors'
+
 module EmailSpec
   module Matchers
     class EmailMatcher
@@ -274,6 +276,7 @@ module EmailSpec
 
       def initialize(text)
         @expected_text = text
+        @extractor = EmailSpec::Extractors::DefaultPartBody
       end
 
       def description
@@ -284,13 +287,23 @@ module EmailSpec
         end
       end
 
+      def in_html_part
+        @extractor = EmailSpec::Extractors::HtmlPartBody
+        self
+      end
+
+      def in_text_part
+        @extractor = EmailSpec::Extractors::TextPartBody
+        self
+      end
+
       def matches?(email)
         if @expected_text.is_a?(String)
-          @given_text = email.default_part_body.to_s.gsub(/\s+/, " ")
+          @given_text = @extractor.new(email).call.to_s.gsub(/\s+/, " ")
           @expected_text = @expected_text.gsub(/\s+/, " ")
           @given_text.include?(@expected_text)
         else
-          @given_text = email.default_part_body.to_s
+          @given_text = @extractor.new(email).call.to_s
           !!(@given_text =~ @expected_text)
         end
       end

--- a/spec/email_spec/matchers_spec.rb
+++ b/spec/email_spec/matchers_spec.rb
@@ -454,6 +454,106 @@ describe EmailSpec::Matchers do
     end
   end
 
+  describe "#have_body_text", ".in_html_part" do
+    describe 'when html part is definded in mulitpart' do
+      it 'should match when the body matches regexp' do
+        email = Mail.new do
+          html_part do
+            body 'This is html'
+          end
+        end
+
+        expect(have_body_text(/This is html/).in_html_part).to match(email)
+      end
+    end
+
+    describe 'when text part is definded in mulitpart' do
+      it 'should not look at text part' do
+        email = Mail.new do
+          text_part do
+            body 'This is text'
+          end
+        end
+
+        expect(have_body_text(/This is text/).in_html_part).not_to match(email)
+      end
+    end
+
+    describe 'when html and text parts are definded in mulitpart' do
+      it 'should look at html part' do
+        email = Mail.new do
+          html_part do
+            body 'This is html'
+          end
+          text_part do
+            body 'This is text'
+          end
+        end
+
+        expect(have_body_text(/This is html/).in_html_part).to match(email)
+        expect(have_body_text(/This is text/).in_html_part).not_to match(email)
+      end
+    end
+
+    describe 'when nothing is defined in mulitpart' do
+      it 'should not look at any parts' do
+        email = Mail.new(body: 'This is body')
+
+        expect(have_body_text(/This is body/).in_html_part).not_to match(email)
+      end
+    end
+  end
+
+  describe "#have_body_text", ".in_text_part" do
+    describe 'when text part is definded in mulitpart' do
+      it 'should match when the body matches regexp' do
+        email = Mail.new do
+          text_part do
+            body 'This is text'
+          end
+        end
+
+        expect(have_body_text(/This is text/).in_text_part).to match(email)
+      end
+    end
+
+    describe 'when text and html parts are definded in mulitpart' do
+      it 'should look at text part' do
+        email = Mail.new do
+          text_part do
+            body 'This is text'
+          end
+
+          html_part do
+            body 'This is html'
+          end
+        end
+
+        expect(have_body_text(/This is text/).in_text_part).to match(email)
+        expect(have_body_text(/This is html/).in_text_part).not_to match(email)
+      end
+    end
+
+    describe 'when html part is definded in mulitpart' do
+      it 'should not look at html part' do
+        email = Mail.new do
+          html_part do
+            body "This is html"
+          end
+        end
+
+        expect(have_body_text(/This is html/).in_text_part).not_to match(email)
+      end
+    end
+
+    describe 'when nothing is defined in mulitpart' do
+      it 'should not look at any parts' do
+        email = Mail.new(body: 'This is body')
+
+        expect(have_body_text(/This is body/).in_text_part).not_to match(email)
+      end
+    end
+  end
   describe "#have_header" do
     describe "when regexps are used" do
       it "should match when header matches passed in regexp" do


### PR DESCRIPTION
I would like to specify which part in multipart is checked by `have_body_text` matcher. In this PR, I added methods (?); `.in_html_part` and `.in_text_part` for `have_body_text` matcher. For example,

```ruby
mail = Mail.new do
   html_part do
     body 'This is html'
   end
   text_part do
     body 'This is text'
   end
end

# The current behavior
expect(mail).to have_body_text(/This is html/)
expect(mail).not_to have_body_text(/This is text/)

# Using new methods created in this PR
expect(mail).to have_body_text(/This is html/).in_html_part
expect(mail).to have_body_text(/This is text/).in_text_part
expect(mail).not_to have_body_text(/This is html).in_text_part # Only look for text part
```