### PR TITLE
Add ruby 2.4 for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.2.3
-  - 2.3.0
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
 before_install:
   - gem update bundler
 before_script:

--- a/examples/rails4_root/Gemfile
+++ b/examples/rails4_root/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 gem "rake", "~> 10.3.2"
-gem 'rails', '4.2.3'
+gem 'rails', '4.2.8'
 gem 'sqlite3'
 
 gem 'delayed_job', '~> 4.0.6'


### PR DESCRIPTION
Also,

* Update 2.1, 2.2, and 2.3
* Drop 2.0

```
Gem::InstallError: nokogiri requires Ruby version >= 2.1.0.
An error occurred while installing nokogiri (1.7.0.1), and Bundler
```