### PR TITLE
Relax the mail version requirement

### DIFF
--- a/email_spec.gemspec
+++ b/email_spec.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "htmlentities", '~> 4.3.3'
   s.add_dependency "launchy", "~> 2.1"
-  s.add_dependency "mail", "~> 2.6.3"
+  s.add_dependency "mail", "~> 2.6"
 
   s.add_development_dependency "rake", ">= 0.8.7"
   s.add_development_dependency "cucumber", '~> 1.3.17'


### PR DESCRIPTION
Removes the patch number from the version requirement of the mail gem,
so versions newer than 2.6.x can be used.

The mail gem adds UTF-8 support in 2.7 and this requirement prevents me
from using it.