### PR TITLE
Fix compatibility issue with Mail 2.7.0

### DIFF
--- a/lib/email_spec/mail_ext.rb
+++ b/lib/email_spec/mail_ext.rb
@@ -4,7 +4,8 @@ module EmailSpec::MailExt
   end
 
   def default_part_body
-    HTMLEntities.new.decode(default_part.body)
+    # Calling to_str as we want the actual String object
+    HTMLEntities.new.decode(default_part.body.to_s.to_str)
   end
 
   def html

--- a/spec/email_spec/mail_ext_spec.rb
+++ b/spec/email_spec/mail_ext_spec.rb
@@ -30,6 +30,11 @@ describe EmailSpec::MailExt do
       email = Mail.new(:body => "hi")
       expect(email.default_part.body).to eq(email.default_part_body)
     end
+
+    it "compatible with ActiveSupport::SafeBuffer" do
+      email = Mail.new(:body => ActiveSupport::SafeBuffer.new("bacon &amp; pancake"))
+      expect(email.default_part_body).to eq ("bacon & pancake")
+    end
   end
 
   describe "#html" do


### PR DESCRIPTION
In Mail 2.7.0 in an actual Rails application, HTML part of the body now returns an `ActiveSupport::SafeBuffer` object instead of a String object. This causes a problem as [there is a known issue of how `SafeBuffer#gsub` with a block form is broken in Rails][1], and that
[`HTMLEntities#decode` actually performs a `gsub` with a block internally][2].

Upon further investigation, however, it seems like the root cause of this issue might not be on Mail gem, but actually on [`ERB::Util.h` returning `ActiveSupport::SafeBuffer` object instead of 
 `String`][3].

This commit changes `default_part_body` method to call `to_s.to_str` on the message body so that we'll be able to pass a String object, which always works with `gsub`, to `HTMLEntities#decode`.

Please note that we need to call `to_s.to_str` on the object because `ActiveSupport::SafeBuffer` actually overrides `to_s` to return itself and not the underlying `String` object.

I believe this PR should fix issue #202, #204, and #205, and it's better to fix the issue here than in `HTMLEntities`.

[1]: https://github.com/rails/rails/issues/1555
[2]: https://github.com/threedaymonk/htmlentities/blob/v4.3.3/lib/htmlentities/decoder.rb#L10-L20
[3]: https://github.com/threedaymonk/htmlentities/issues/33#issuecomment-348952735