### PR TITLE
decode part in EmailSpec::MailExt#default_part_body

### DIFF
--- a/lib/email_spec/mail_ext.rb
+++ b/lib/email_spec/mail_ext.rb
@@ -5,11 +5,11 @@ module EmailSpec::MailExt
 
   def default_part_body
     # Calling to_str as we want the actual String object
-    HTMLEntities.new.decode(default_part.body.to_s.to_str)
+    HTMLEntities.new.decode(default_part.decoded.to_s.to_str)
   end
 
   def html
-    html_part ? html_part.body.raw_source : nil
+    html_part ? html_part.decoded : nil
   end
 end
 

--- a/spec/email_spec/mail_ext_spec.rb
+++ b/spec/email_spec/mail_ext_spec.rb
@@ -35,6 +35,13 @@ describe EmailSpec::MailExt do
       email = Mail.new(:body => ActiveSupport::SafeBuffer.new("bacon &amp; pancake"))
       expect(email.default_part_body).to eq ("bacon & pancake")
     end
+
+    it "decodes parts before return" do
+      email = Mail.new(:body => "hello\r\nquoted-printable")
+      email.content_transfer_encoding = 'quoted-printable'
+      expect(email.encoded).to include("hello=0D\nquoted-printable")
+      expect(email.default_part_body).to eq("hello\r\nquoted-printable")
+    end
   end
 
   describe "#html" do


### PR DESCRIPTION
Because any part of Message can be encoded with any of [Mail::Encodings](https://github.com/mikel/mail/tree/master/lib/mail/encodings) we need to decode them in EmailSpec::MailExt#default_part_body.