### PR TITLE
Support the specified name and address for `bcc_to` and `cc_to` matchers

### DIFF
--- a/lib/email_spec/matchers.rb
+++ b/lib/email_spec/matchers.rb
@@ -128,7 +128,7 @@ module EmailSpec
 
       def matches?(email)
         @email = email
-        @actual_recipients = address_array{ email.bcc }.sort
+        @actual_recipients = address_array { email[:bcc].formatted }.sort
         @actual_recipients == @expected_email_addresses
       end
 
@@ -162,7 +162,7 @@ module EmailSpec
 
       def matches?(email)
         @email = email
-        @actual_recipients = address_array { email.cc }.sort
+        @actual_recipients = address_array { email[:cc].formatted }.sort
         @actual_recipients == @expected_email_addresses
       end
 

--- a/spec/email_spec/matchers_spec.rb
+++ b/spec/email_spec/matchers_spec.rb
@@ -178,6 +178,12 @@ describe EmailSpec::Matchers do
       expect(bcc_to("jimmy_bean@yahoo.com")).to match(email)
     end
 
+    it "should match when the email is set to deliver to the specified name and address" do
+      email = Mail::Message.new(:bcc => "Jimmy Bean <jimmy_bean@yahoo.com>")
+
+      expect(bcc_to("Jimmy Bean <jimmy_bean@yahoo.com>")).to match(email)
+    end
+
     it "should match when a list of emails is exact same as all of the email's recipients" do
       email = Mail::Message.new(:bcc => ["james@yahoo.com", "karen@yahoo.com"])
 
@@ -212,6 +218,12 @@ describe EmailSpec::Matchers do
       email = Mail::Message.new(:cc => "jimmy_bean@yahoo.com")
 
       expect(cc_to("jimmy_bean@yahoo.com")).to match(email)
+    end
+
+    it "should match when the email is set to deliver to the specified name and address" do
+      email = Mail::Message.new(:cc => "Jimmy Bean <jimmy_bean@yahoo.com>")
+
+      expect(cc_to("Jimmy Bean <jimmy_bean@yahoo.com>")).to match(email)
     end
 
     it "should match when a list of emails is exact same as all of the email's recipients" do


### PR DESCRIPTION
This PR supports specified name and address for `bcc_to` and `cc_to` matchers.