### PR TITLE
Drop rubyforge_project from gemspec.

### DIFF
--- a/email_spec.gemspec
+++ b/email_spec.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
              Dir['spec/**/*']
   s.homepage = "http://github.com/email-spec/email-spec/"
   s.require_paths = ["lib"]
-  s.rubyforge_project = "email-spec"
   s.rubygems_version = "1.8.10"
   s.summary = "Easily test email in RSpec, Cucumber or Minitest"
 


### PR DESCRIPTION
`Gem::Specification#rubyforge_project` is deprecated at the next version of rubygems.