### PR TITLE
Avoid eagerly loading ActionMailer::Base

### DIFF
--- a/lib/email_spec/deliveries.rb
+++ b/lib/email_spec/deliveries.rb
@@ -73,12 +73,19 @@ module EmailSpec
     if defined?(Pony)
       def deliveries; Pony::deliveries ; end
       include EmailSpec::MailerDeliveries
-    elsif ActionMailer::Base.delivery_method == :activerecord
-      include EmailSpec::ARMailerDeliveries
     else
-      def mailer; ActionMailer::Base; end
-      include EmailSpec::MailerDeliveries
+      ActiveSupport.on_load(:action_mailer) do
+        if delivery_method == :activerecord
+          ::EmailSpec::Helpers.include EmailSpec::ARMailerDeliveries
+        else
+          ::EmailSpec::Deliveries.module_eval do
+            def mailer
+              ActionMailer::Base
+            end
+          end
+          ::EmailSpec::Helpers.include ::EmailSpec::MailerDeliveries
+        end
+      end
     end
   end
 end
-

--- a/spec/email_spec/mail_ext_spec.rb
+++ b/spec/email_spec/mail_ext_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'active_support'
 
 describe EmailSpec::MailExt do
   describe "#default_part" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,9 @@ require 'action_mailer'
 require 'mail'
 require File.expand_path(File.dirname(__FILE__) + '/../lib/email_spec.rb')
 
+# Trigger loading ActionMailer::Base
+ActionMailer::Base
+
 RSpec.configure do |config|
   config.include EmailSpec::Helpers
   config.include EmailSpec::Matchers


### PR DESCRIPTION
ActionMailer::Base is lazily loaded by Rails and we don't want to prematurely load it, otherwise it may be loaded before initialization runs, then any configuration set in initialization is not copied over to ActionMailer::Base internally.