### PR TITLE
Replace deprecated/removed `File.exists?` alias

### DIFF
--- a/features/step_definitions/app_steps.rb
+++ b/features/step_definitions/app_steps.rb
@@ -6,13 +6,13 @@ Given /^the (\w+) app is setup with the latest email steps$/ do |app_name|
                                'email_steps.rb')
   latest_specs_path = File.join(root_dir, 'lib', 'generators', 'email_spec',
                                 'steps', 'templates','email_steps.rb')
-  FileUtils.rm(email_specs_path) if File.exists?(email_specs_path)
+  FileUtils.rm(email_specs_path) if File.exist?(email_specs_path)
   FileUtils.cp_r(latest_specs_path, email_specs_path)
 end
 
 Then /^the (\w+) app should have the email steps in place$/ do |app_name|
   email_specs_path = "#{root_dir}/examples/#{app_name}_root/features/step_definitions/email_steps.rb"
-  expect(File.exists?(email_specs_path)).to be true
+  expect(File.exist?(email_specs_path)).to be true
 end
 
 Then /^I should see the following summary report:$/ do |expected_report|
@@ -22,7 +22,7 @@ end
 Given /^the (\w+) app is setup with the latest generators$/ do |app_name|
   app_dir= File.join(root_dir,'examples',"#{app_name}_root")
   email_specs_path = File.join(app_dir,'features','step_definitions','email_steps.rb')
-  FileUtils.rm(email_specs_path) if File.exists?(email_specs_path)
+  FileUtils.rm(email_specs_path) if File.exist?(email_specs_path)
 
   if app_name == 'rails4'
     #Testing using the gem
@@ -46,7 +46,7 @@ When /^I run "([^\"]*)" in the (\w+) app$/ do |cmd, app_name|
   app_specific_gemfile = File.join(app_path,'Gemfile')
   Dir.chdir(app_path) do
     #hack to fight competing bundles (email specs vs rails4_root's
-    if File.exists? app_specific_gemfile
+    if File.exist? app_specific_gemfile
       orig_gemfile = ENV['BUNDLE_GEMFILE']
       ENV['BUNDLE_GEMFILE'] = app_specific_gemfile
       @output = `#{cmd}`


### PR DESCRIPTION
The alias `File.exists?` was removed in Ruby 3.2:

* https://bugs.ruby-lang.org/issues/17391
* https://rubyreferences.github.io/rubychanges/3.2.html#removals

`File.exist?` has been in Ruby since at least 1.8: https://ruby-doc.org/core-1.8.6/File.html#method-c-exist-3F