### PR TITLE
Defer accommodating different delivery methods to runtime

### DIFF
--- a/spec/email_spec/mail_ext_spec.rb
+++ b/spec/email_spec/mail_ext_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'active_support'
 
 describe EmailSpec::MailExt do
   describe "#default_part" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,6 @@ require 'action_mailer'
 require 'mail'
 require File.expand_path(File.dirname(__FILE__) + '/../lib/email_spec.rb')
 
-# Trigger loading ActionMailer::Base
-ActionMailer::Base
-
 RSpec.configure do |config|
   config.include EmailSpec::Helpers
   config.include EmailSpec::Matchers


### PR DESCRIPTION
After #219, ActionMailer became lazily loaded, leading to this library hooking into RSpec potentially before including the module specific to the delivery method in use, so RSpec never saw the delivery method-specific module, leading to errors as documented in #221.

Now, the individual methods (ie. `reset_mailer`, `deliveries`) are responsible for branching based on the correct delivery method, defining their corresponding implementation.

Thinking longer term, there's no guarantee a single delivery method is used across the board (though that's likely the most common scenario), so rather than branching, we should probably iterate through all supported delivery methods. #216 touches on this, where instead of assuming Pony OR ActionMailer, both should likely be supported simultaneously, searching each for a given email, and resetting all.

Fixes #221